### PR TITLE
Update 2_2_视频入门.md

### DIFF
--- a/ThirdSection/2_2_视频入门.md
+++ b/ThirdSection/2_2_视频入门.md
@@ -31,7 +31,7 @@ while True:
         break
     # 我们在框架上的操作到这里
     gray = cv.cvtColor(frame, cv.COLOR_BGR2GRAY)
-    # 显示结果帧e
+    # 显示结果帧
     cv.imshow('frame', gray)
     if cv.waitKey(1) == ord('q'):
         break
@@ -104,7 +104,7 @@ while cap.isOpened():
         print("Can't receive frame (stream end?). Exiting ...")
         break
     frame = cv.flip(frame, 0)
-    # 写翻转的框架
+    # 写翻转后的帧
     out.write(frame)
     cv.imshow('frame', frame)
     if cv.waitKey(1) == ord('q'):


### PR DESCRIPTION
更正一处翻译错误：frame应译为“帧“而非"框架"。